### PR TITLE
Remove ! from use_sched_ahead_time

### DIFF
--- a/sonicPiTheremin.txt
+++ b/sonicPiTheremin.txt
@@ -1,5 +1,5 @@
 live_loop :foo do
-   use_sched_ahead_time! 0.1
-   message = sync “/osc/play_this”
+   use_sched_ahead_time 0.1
+   message = sync "/osc/play_this"
    play message
 end


### PR DESCRIPTION
Not sure what the ```!``` refers to but it caused an error for me so I removed it.